### PR TITLE
Doc PR for config-impl

### DIFF
--- a/docs/atllbuild.md
+++ b/docs/atllbuild.md
@@ -88,9 +88,6 @@ The `atllbuild` tool uses the [`swift-llbuild`](https://github.com/apple/swift-l
     ;; This is currently only supported on the xcode toolchain, see SR-1493 for details
     :bitcode false
     
-    ;; Platform-specific compile/link options you almost certainly want.
-    ;; Set this to false to disable these and then you can replace with your own flags in the atpkg
-    :magic true
   }
 }
         

--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -18,11 +18,13 @@ To specify a configuration, pass it on the command line:
 
 Tools adjust their behavior to your chosen configuration automatically.  You can also provide your own settings in an `atbuild.configuration.[configurationname]` overlay.
 
+# In Swift
+
+configurations are exported to swift via the `ATBUILD_DEBUG`, `ATBUILD_RELEASE`, `ATBUILD_TEST` and `ATBUILD_BENCH` preprocessor defines.  Custom configurations are exposed as `ATBUILD_\(name)`.  `none` has no associated define.
+
 # Internal API
 
 `atbuild` provides a rich internal API.  Properties are exposed on the configuration object as well as via environment variable for shell / external tools.
-
-Other than the first one, these are boolean properties that can be `true`, `false`, or `nil`/absent (meaning we don't know the correct value).
 
 ## `ATBUILD_CONFIGURATION` / `currentConfiguration`
 
@@ -32,14 +34,26 @@ This is the active configuration.  Note that using this value directly is discou
 
 Whether to produce optimized software.
 
+A boolean property that can be `true`, `false`, or `nil`/absent (meaning we don't know the correct value).
+
 ## `ATBUILD_CONFIGURATION_FAST_COMPILE` / `fastCompile`
 
 Whether to prioritize compile speed over compile quality.  When this is `true`, you might be in the middle of a compile-run-test loop, so avoid doing anything expensive.
+
+A boolean property that can be `true`, `false`, or `nil`/absent (meaning we don't know the correct value).
 
 ## `ATBUILD_CONFIGURATION_TESTING_ENABLED` / `testingEnabled`
 
 Whether to compile "for testing".  This may control behaviors such as whether tests are compiled at all, whether the build product can be imported with `@testable`, or unlock other behavior related to testing.
 
+A boolean property that can be `true`, `false`, or `nil`/absent (meaning we don't know the correct value).
+
 ##  `ATBUILD_CONFIGURATION_NO_MAGIC` / `noMagic`
 
 Whether we should "opt out" of all magical behavior and rely only on explicit task options.  For example, no SDK might be selected, requiring the user to specify one manually.  Builds may be single-threaded.  Etc.
+
+A boolean property that can be `true`, `false`, or `nil`/absent (meaning we don't know the correct value).
+
+## `ATBUILD_CONFIGURATION_DEBUG_INSTRUMENTATION` / `debugInstrumentation`
+
+What type of debug instrumentation (e.g. debug symbols) should be used.  Choices are `omitted` (no instrumentation) `included` (instrumentation in the target) or `stripped` (instrumentation in a separate file).


### PR DESCRIPTION
Doc PR for https://github.com/AnarchyTools/atbuild/pull/111
- Document the deprecation of atllbuild `magic`
- Document `ATBUILD_DEBUG`, `ATBUILD_RELEASE`, `ATBUILD_TEST` and `ATBUILD_BENCH`
- Document `ATBUILD_CONFIGURATION_DEBUG_INSTRUMENTATION` internal API
